### PR TITLE
build: Bionic support

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -21,14 +21,6 @@ bases:
       architectures: ["amd64"]
     run-on:
       - name: ubuntu
-        channel: "22.04"
-        architectures:
-          - amd64
-      - name: ubuntu
-        channel: "20.04"
-        architectures:
-          - amd64
-      - name: ubuntu
         channel: "18.04"
         architectures:
           - amd64
@@ -37,14 +29,6 @@ bases:
       channel: "22.04"
       architectures: ["arm64"]
     run-on:
-      - name: ubuntu
-        channel: "22.04"
-        architectures:
-          - arm64
-      - name: ubuntu
-        channel: "20.04"
-        architectures:
-          - arm64
       - name: ubuntu
         channel: "18.04"
         architectures:

--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -1,2 +1,0 @@
-setuptools>=42
-flit-core>=3


### PR DESCRIPTION
- Drop dependency pin on wheelhouse to follow the practice on https://github.com/canonical/layer-basic/blob/24324f8dab91bb304f7400dadc263ac6106268cb/wheelhouse.txt
- Drop focal and jammy support to avoid misuse.

Relate to: #83 
Partial fix: #79 

---

This version is intended to support Bionic deployments.
Since Bionic is no longer supported and this charm is in maintenance mode, this serves as a workaround to unblock Bionic deployment.

**Note for release:**

This will be released manually to latest/stable to provide final revision for Bionic support. This allows users on Bionic to easily refresh to latest/stable, while deployments on Focal or Jammy will remain unaffected.

Below is the expected result:

```
rev50 <- current revision, support bionic, focal, jammy
rev51 <- Support bionic
rev52 <- Support focal, jammy
``` 

All the revision will be release to latest/stable channel. So user on focal/jammy will refresh to rev52 and user on bionic will refresh to 51.