### PR TITLE
Pin pbr to fix install

### DIFF
--- a/src/layer.yaml
+++ b/src/layer.yaml
@@ -28,4 +28,4 @@ options:
     apt:
         packages:
             - cpufrequtils
-repo: https://git.launchpad.net/charm-sysconfig
+repo: https://github.com/canonical/charm-sysconfig

--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -1,2 +1,4 @@
 setuptools>=42
 flit-core>=3
+# NOTE: pbr 6.1.1 introduced a dependency on setuptools>=64, which is not available in the build environment constraints.
+pbr==6.1.0


### PR DESCRIPTION
pbr release 6.1.1 added setuptools >= 64.0.0 as a build dependency. However, due to other constraints the maximum version of setuptools available to install is 59.6.0.