### PR TITLE
Make cpufrequtils optional

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -163,6 +163,9 @@ options:
                         Recommended option when Bios control power is set to the OS.
         - 'performance'
         - 'powersave'
+
+        On some architectures, cpufrequtils is not available.
+        In these cases, this config option will be ignored.
   resolved-cache-mode:
     type: string
     default: ""

--- a/src/layer.yaml
+++ b/src/layer.yaml
@@ -25,7 +25,4 @@ options:
         include_system_packages: true
         packages:
             - python3-yaml
-    apt:
-        packages:
-            - cpufrequtils
 repo: https://github.com/canonical/charm-sysconfig

--- a/src/lib/lib_sysconfig.py
+++ b/src/lib/lib_sysconfig.py
@@ -666,7 +666,9 @@ class SysConfigHelper:
         and installation was successful.
         """
         apt_update()
-        if subprocess.check_output(['apt-cache', 'search', '--names-only', '^cpufrequtils$']).strip():
+        if subprocess.check_output(
+            ["apt-cache", "search", "--names-only", "^cpufrequtils$"]
+        ).strip():
             apt_install("cpufrequtils", fatal=True)
             return True
         else:

--- a/src/lib/lib_sysconfig.py
+++ b/src/lib/lib_sysconfig.py
@@ -659,6 +659,19 @@ class SysConfigHelper:
         apt_install("linux-image-{}".format(configured))
         self.boot_resources.set_resource(KERNEL)
 
+    def install_cpufrequtils(self):
+        """Install cpufrequtils if available.
+
+        Return True if cpufrequtils is available
+        and installation was successful.
+        """
+        apt_update()
+        if subprocess.check_output(['apt-cache', 'search', '--names-only', '^cpufrequtils$']).strip():
+            apt_install("cpufrequtils", fatal=True)
+            return True
+        else:
+            return False
+
     def update_cpufreq(self):
         """Update /etc/default/cpufrequtils and restart cpufrequtils service."""
         if self.governor not in ("", "performance", "powersave"):

--- a/src/reactive/sysconfig.py
+++ b/src/reactive/sysconfig.py
@@ -93,7 +93,8 @@ def config_changed():
 
     # cpufreq
     if is_flag_set("sysconfig.cpufrequtils-installed") and (
-        syshelper.charm_config.changed("governor") or helpers.any_file_changed([CPUFREQUTILS])
+        syshelper.charm_config.changed("governor")
+        or helpers.any_file_changed([CPUFREQUTILS])
     ):
         syshelper.update_cpufreq()
 

--- a/src/reactive/sysconfig.py
+++ b/src/reactive/sysconfig.py
@@ -60,6 +60,11 @@ def install_sysconfig():
 
     if syshelper.install_cpufrequtils():
         set_flag("sysconfig.cpufrequtils-installed")
+    else:
+        hookenv.log(
+            "cpufrequtils package not found: governor config option will be ignored.",
+            hookenv.WARNING,
+        )
 
     syshelper.install_configured_kernel()
 

--- a/src/tests/unit/test_lib.py
+++ b/src/tests/unit/test_lib.py
@@ -1062,7 +1062,7 @@ class TestLib:
 
         mock_file.assert_called_with(lib_sysconfig.SYSCTL_CONF, "w")
         handle = mock_file()
-        handle.write.has_calls(
+        handle.write.assert_has_calls(
             [mock.call("net.ipv4.ip_forward=1\n"), mock.call("vm.swappiness=60\n")]
         )
         check_call.assert_called_with(["sysctl", "-p", lib_sysconfig.SYSCTL_CONF])

--- a/src/tests/unit/test_lib.py
+++ b/src/tests/unit/test_lib.py
@@ -1101,3 +1101,39 @@ class TestLib:
         )
 
         restart.assert_called()
+
+    @mock.patch("lib_sysconfig.apt_install")
+    @mock.patch("lib_sysconfig.apt_update")
+    @mock.patch("lib_sysconfig.subprocess")
+    @mock.patch("lib_sysconfig.hookenv.config")
+    def test_install_cpufrequtils_success(
+        self, _mock_config, mock_subprocess, mock_apt_update, mock_apt_install
+    ):
+        """Verify it does install cpufrequtils when it's available."""
+        mock_subprocess.check_output.return_value = (
+            "cpufrequtils - utilities to deal with the cpufreq Linux kernel feature"
+        )
+        sysh = lib_sysconfig.SysConfigHelper()
+
+        result = sysh.install_cpufrequtils()
+
+        assert result is True
+        mock_apt_update.assert_called_once_with()
+        mock_apt_install.assert_called_once_with("cpufrequtils", fatal=True)
+
+    @mock.patch("lib_sysconfig.apt_install")
+    @mock.patch("lib_sysconfig.apt_update")
+    @mock.patch("lib_sysconfig.subprocess")
+    @mock.patch("lib_sysconfig.hookenv.config")
+    def test_install_cpufrequtils_not_found(
+        self, _mock_config, mock_subprocess, mock_apt_update, mock_apt_install
+    ):
+        """Verify it doesn't install cpufrequtils when it's not available."""
+        mock_subprocess.check_output.return_value = ""
+        sysh = lib_sysconfig.SysConfigHelper()
+
+        result = sysh.install_cpufrequtils()
+
+        assert result is False
+        mock_apt_update.assert_called_once_with()
+        mock_apt_install.assert_not_called()

--- a/tox.ini
+++ b/tox.ini
@@ -31,13 +31,13 @@ passenv =
 
 [testenv:lint]
 commands =
-    pflake8
+    flake8
     black --check --diff --color .
     isort --check --diff --color .
 deps =
     black<24.0.0 # TODO: Remove pin once we make our linter pass on it
     flake8
-    pyproject-flake8
+    flake8-pyproject
     flake8-docstrings
     pep8-naming
     flake8-colors

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,6 @@ deps =
     isort
 
 [testenv:reformat]
-envdir = {toxworkdir}/lint
 commands =
     black .
     isort .


### PR DESCRIPTION
cpufrequtils is not available on some architectures, such as PowerPC machines.
In these cases, previously the charm would fail to install, crashing on trying to install cpufrequtils.

So now the charm will install cpufrequtils if it is available and continue as usual.
If cpufrequtils is not available however,
the charm will skip attempting to install cpufrequtils, and ignore the governor config option.

Fixes: #87 